### PR TITLE
Keep `posts` example consistent in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,16 +109,16 @@ A collection maps to a folder in your filesystem of choice. Sheets will look for
 return [
     'disks' => [
         // ...
-        'pages' => [
+        'posts' => [
             'driver' => 'local',
-            'root' => base_path('pages'),
+            'root' => base_path('posts'),
         ],
     ],
 ];
 
 // config/sheets.php
 return [
-    'collections' => ['pages'],
+    'collections' => ['posts'],
 ];
 ```
 


### PR DESCRIPTION
Not sure if this was intended like this or not but i feel like it reads easier like this