### PR TITLE
Implements ArrayAccess on Sheet class

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\Sheets;
 
-class Sheet
+use ArrayAccess;
+
+class Sheet implements ArrayAccess
 {
     /** @var array */
     protected $attributes;
@@ -14,6 +16,46 @@ class Sheet
 
     public function __get(string $key)
     {
+        return $this->getAttribute($key);
+    }
+
+    public function __set(string $key, $value)
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    public function __isset(string $key)
+    {
+        return isset($this->attributes[$key]);
+    }
+
+    public function __unset(string $key)
+    {
+        unset($this->attributes[$key]);
+    }
+
+    public function offsetExists($key)
+    {
+        return !is_null($this->getAttribute($key));
+    }
+
+    public function offsetGet($key)
+    {
+        return $this->getAttribute($key);
+    }
+
+    public function offsetSet($key, $value)
+    {
+        $this->$key = $value;
+    }
+
+    public function offsetUnset($key)
+    {
+        unset($this->attributes[$key]);
+    }
+
+    protected function getAttribute(string $key)
+    {
         $value = $this->attributes[$key] ?? null;
 
         $accessorFunctionName = 'get'.studly_case($key).'Attribute';
@@ -23,15 +65,5 @@ class Sheet
         }
 
         return $value;
-    }
-
-    protected function __set(string $key, $value)
-    {
-        $this->attributes[$key] = $value;
-    }
-
-    public function __isset(string $key)
-    {
-        return ! is_null($this->$key);
     }
 }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -25,6 +25,11 @@ class Sheet
         return $value;
     }
 
+    protected function __set(string $key, $value)
+    {
+        $this->attributes[$key] = $value;
+    }
+
     public function __isset(string $key)
     {
         return ! is_null($this->$key);

--- a/tests/Repositories/FilesystemRepositoryTest.php
+++ b/tests/Repositories/FilesystemRepositoryTest.php
@@ -58,7 +58,7 @@ class FilesystemRepositoryTest extends TestCase
         $sheet->attribute = 'attribute_name';
         unset($sheet->attribute);
 
-        // $this->assertFalse(isset($sheet->attribute));
+        $this->assertFalse(isset($sheet->attribute));
     }
 
     /** @test */

--- a/tests/Repositories/FilesystemRepositoryTest.php
+++ b/tests/Repositories/FilesystemRepositoryTest.php
@@ -58,7 +58,7 @@ class FilesystemRepositoryTest extends TestCase
         $sheet->attribute = 'attribute_name';
         unset($sheet->attribute);
 
-        $this->assertFalse(isset($sheet->attribute));
+        // $this->assertFalse(isset($sheet->attribute));
     }
 
     /** @test */

--- a/tests/SheetTest.php
+++ b/tests/SheetTest.php
@@ -40,6 +40,19 @@ class SheetTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_specific_attribute()
+    {
+        $sheet = new Sheet();
+
+        $sheet->foo = 'bar';
+
+        $reflection = (new ReflectionClass($sheet))->getProperty('attributes');
+        $reflection->setAccessible(true);
+
+        $this->assertEquals(['foo' => 'bar'], $reflection->getValue($sheet));
+    }
+
+    /** @test */
     public function it_can_be_extended_with_accessor()
     {
         $child = new class extends Sheet {

--- a/tests/SheetTest.php
+++ b/tests/SheetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\Sheets\Tests;
+
+use ReflectionClass;
+use Spatie\Sheets\Sheet;
+use PHPUnit\Framework\TestCase;
+
+class SheetTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_a_sheet_with_attributes()
+    {
+        $attributes = [
+            'foo' => 'bar',
+            'hello' => 'world',
+        ];
+        $sheet = new Sheet($attributes);
+
+        $reflection = (new ReflectionClass($sheet))->getProperty('attributes');
+        $reflection->setAccessible(true);
+
+        $this->assertEquals($attributes, $reflection->getValue($sheet));
+    }
+
+    /** @test */
+    public function it_can_get_a_specific_attribute()
+    {
+        $sheet = new Sheet(['foo' => 'bar']);
+        
+        $this->assertEquals('bar', $sheet->foo);
+    }
+
+    /** @test */
+    public function it_can_get_null_for_a_non_existing_attribute()
+    {
+        $sheet = new Sheet();
+        
+        $this->assertNull($sheet->unknown);
+    }
+
+    /** @test */
+    public function it_can_be_extended_with_accessor()
+    {
+        $child = new class extends Sheet {
+            public function getFooAttribute($original)
+            {
+                return 'baz';
+            }
+        };
+
+        $sheet = new $child(['foo' => 'bar']);
+
+        $this->assertNotEquals('bar', $sheet->foo);
+        $this->assertEquals('baz', $sheet->foo);
+    }
+}

--- a/tests/SheetTest.php
+++ b/tests/SheetTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Sheets\Tests;
 
+use ArrayAccess;
 use ReflectionClass;
 use Spatie\Sheets\Sheet;
 use PHPUnit\Framework\TestCase;
@@ -66,5 +67,21 @@ class SheetTest extends TestCase
 
         $this->assertNotEquals('bar', $sheet->foo);
         $this->assertEquals('baz', $sheet->foo);
+    }
+
+    /** @test */
+    public function it_implements_array_access()
+    {
+        $sheet = new Sheet(['foo' => 'bar']);
+
+        $this->assertInstanceOf(ArrayAccess::class, $sheet);
+        $this->assertEquals('bar', $sheet['foo']);
+        $this->assertNull($sheet['unknown']);
+
+        unset($sheet['foo']);
+        $this->assertNull($sheet['foo']);
+
+        $sheet['foo'] = 'baz';
+        $this->assertEquals('baz', $sheet['foo']);
     }
 }


### PR DESCRIPTION
Hi !

First, thanks for the good work. 

I thought it could be useful to add ArrayAccess to mimic Eloquent models a little more.

The PR:
- adds some basic tests on Sheet class, 
- implements `__set` to to set an attribute directly in `$attributes` property (I think it fits better with ArrayAccess)
- finally implements ArrayAccess 😎