### PR TITLE
README wrong variable used for sheet contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class SheetController
 ])
 
 @section('main')
-    {{ $sheet->content }}
+    {{ $sheet->contents }}
 @endsection
 ```
 


### PR DESCRIPTION
The attribute for getting the compiled contents of a sheet should be $sheet->contents instead of $sheet->content.