### PR TITLE
Use correct namespace for Sheets in Route Model Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,10 @@ class SheetsController
 It might be useful to register specific bindings for other collections.
 
 ```php
+use Spatie\Sheets\Sheets;
+
 Route::bind('post', function ($path) {
-    return $this->app->make(Spatie\Sheets\Sheets::class)
+    return $this->app->make(Sheets::class)
         ->collection('posts')
         ->get($path) ?? abort(404);
 });


### PR DESCRIPTION
Or you could prefix it with a slash, both ways would work.