### PR TITLE
Fix str studly for Laravel 6

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -4,6 +4,7 @@ namespace Spatie\Sheets;
 
 use ArrayAccess;
 use JsonSerializable;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
@@ -90,7 +91,7 @@ class Sheet implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     {
         $value = $this->attributes[$key] ?? null;
 
-        $accessorFunctionName = 'get'.studly_case($key).'Attribute';
+        $accessorFunctionName = 'get'.Str::studly($key).'Attribute';
 
         if (method_exists($this, $accessorFunctionName)) {
             return $this->$accessorFunctionName($value);


### PR DESCRIPTION
Replace `studly_case` helper with `Str::studly` since the first one was removed in Laravel 6 release.