### PR TITLE
allow to use a custom repository

### DIFF
--- a/src/ContentParsers/JsonParser.php
+++ b/src/ContentParsers/JsonParser.php
@@ -3,7 +3,6 @@
 namespace Spatie\Sheets\ContentParsers;
 
 use Spatie\Sheets\ContentParser;
-use Symfony\Component\Yaml\Yaml;
 
 class JsonParser implements ContentParser
 {

--- a/src/Repositories/FilesystemRepository.php
+++ b/src/Repositories/FilesystemRepository.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\Sheets\Repositories;
 
-use Spatie\Sheets\Sheet;
-use Spatie\Sheets\Factory;
-use Illuminate\Support\Str;
-use Spatie\Sheets\Repository;
-use Illuminate\Support\Collection;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemManagerContract;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Spatie\Sheets\Factory;
+use Spatie\Sheets\Repository;
+use Spatie\Sheets\Sheet;
 
 class FilesystemRepository implements Repository
 {
@@ -29,11 +29,11 @@ class FilesystemRepository implements Repository
 
     public function get(string $path): ?Sheet
     {
-        if (!Str::endsWith($path, $this->extension)) {
+        if (! Str::endsWith($path, $this->extension)) {
             $path = "{$path}.{$this->extension}";
         }
 
-        if (!$this->filesystem->exists($path)) {
+        if (! $this->filesystem->exists($path)) {
             return null;
         }
 

--- a/src/Repositories/FilesystemRepository.php
+++ b/src/Repositories/FilesystemRepository.php
@@ -7,7 +7,7 @@ use Spatie\Sheets\Factory;
 use Illuminate\Support\Str;
 use Spatie\Sheets\Repository;
 use Illuminate\Support\Collection;
-use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemManagerContract;
 
 class FilesystemRepository implements Repository
 {
@@ -20,11 +20,11 @@ class FilesystemRepository implements Repository
     /** @var string */
     protected $extension;
 
-    public function __construct(Factory $factory, Filesystem $filesystem, string $extension = 'md')
+    public function __construct(Factory $factory, FilesystemManagerContract $filesystem, array $config = [])
     {
         $this->factory = $factory;
-        $this->filesystem = $filesystem;
-        $this->extension = $extension;
+        $this->filesystem = $filesystem->disk($config['disk'] ?? null);
+        $this->extension = $config['extension'] ?? 'md';
     }
 
     public function get(string $path): ?Sheet

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -3,11 +3,11 @@
 namespace Spatie\Sheets;
 
 use ArrayAccess;
-use JsonSerializable;
-use Illuminate\Support\Str;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Support\Str;
+use JsonSerializable;
 
 class Sheet implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 {
@@ -46,7 +46,7 @@ class Sheet implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 
     public function offsetExists($key)
     {
-        return !is_null($this->getAttribute($key));
+        return ! is_null($this->getAttribute($key));
     }
 
     public function offsetGet($key)
@@ -68,7 +68,7 @@ class Sheet implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     {
         $keys = array_keys($this->attributes);
 
-        return array_map(function(string $key) {
+        return array_map(function (string $key) {
             return $this->getAttribute($key);
         }, array_combine($keys, $keys));
     }

--- a/src/Sheets.php
+++ b/src/Sheets.php
@@ -22,7 +22,8 @@ class Sheets implements Repository
         return $this->collections[$name];
     }
 
-    public function registerCollection(string $name, Repository $repository) {
+    public function registerCollection(string $name, Repository $repository)
+    {
         $this->collections[$name] = $repository;
     }
 

--- a/src/SheetsServiceProvider.php
+++ b/src/SheetsServiceProvider.php
@@ -60,11 +60,7 @@ class SheetsServiceProvider extends ServiceProvider
                     $config['sheet_class']
                 );
 
-                $repository = new FilesystemRepository(
-                    $factory,
-                    $this->app->make(FilesystemManager::class)->disk($config['disk']),
-                    $config['extension']
-                );
+                $repository = $this->app->make($config['repository'], compact('factory', 'config'));
 
                 $sheets->registerCollection($name, $repository);
             }
@@ -87,6 +83,7 @@ class SheetsServiceProvider extends ServiceProvider
             'path_parser' => SlugParser::class,
             'content_parser' => MarkdownWithFrontMatterParser::class,
             'extension' => 'md',
+            'repository' => FilesystemRepository::class,
         ];
 
         return array_merge($defaults, $config);

--- a/src/SheetsServiceProvider.php
+++ b/src/SheetsServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Sheets;
 
-use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Support\ServiceProvider;
 use League\CommonMark\CommonMarkConverter;
 use Spatie\Sheets\ContentParsers\MarkdownParser;

--- a/tests/Concerns/UsesFilesystem.php
+++ b/tests/Concerns/UsesFilesystem.php
@@ -2,19 +2,34 @@
 
 namespace Spatie\Sheets\Tests\Concerns;
 
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem as Flysystem;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemManagerContract;
 
 trait UsesFilesystem
 {
-    protected function createFilesystem(): Filesystem
+    protected function createFilesystem(): FilesystemManagerContract
     {
         $adapter = new Local(__DIR__.'/../fixtures/content');
 
         $flysystem = new Flysystem($adapter);
 
-        return new FilesystemAdapter($flysystem);
+        $adapter = new FilesystemAdapter($flysystem);
+
+        return new class($adapter) implements FilesystemManagerContract
+        {
+            private $adapter;
+
+            public function __construct($adapter)
+            {
+                $this->adapter = $adapter;
+            }
+
+            public function disk($name = null)
+            {
+                return $this->adapter;
+            }
+        };
     }
 }

--- a/tests/Concerns/UsesFilesystem.php
+++ b/tests/Concerns/UsesFilesystem.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Sheets\Tests\Concerns;
 
+use Illuminate\Contracts\Filesystem\Factory as FilesystemManagerContract;
 use Illuminate\Filesystem\FilesystemAdapter;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem as Flysystem;
-use Illuminate\Contracts\Filesystem\Factory as FilesystemManagerContract;
 
 trait UsesFilesystem
 {
@@ -17,8 +17,7 @@ trait UsesFilesystem
 
         $adapter = new FilesystemAdapter($flysystem);
 
-        return new class($adapter) implements FilesystemManagerContract
-        {
+        return new class($adapter) implements FilesystemManagerContract {
             private $adapter;
 
             public function __construct($adapter)

--- a/tests/ContentParsers/JsonParserTest.php
+++ b/tests/ContentParsers/JsonParserTest.php
@@ -4,9 +4,6 @@ namespace Spatie\Sheets\Tests\ContentParsers;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\Sheets\ContentParsers\JsonParser;
-use Spatie\Sheets\ContentParsers\MarkdownParser;
-use League\CommonMark\CommonMarkConverter;
-use Spatie\Sheets\ContentParsers\YamlParser;
 
 class JsonParserTest extends TestCase
 {
@@ -21,8 +18,8 @@ class JsonParserTest extends TestCase
                 'data' => [
                     'foo',
                     'bar',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expected, $jsonParser->parse(json_encode($expected)));

--- a/tests/ContentParsers/MarkdownParserTest.php
+++ b/tests/ContentParsers/MarkdownParserTest.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Sheets\Tests\ContentParsers;
 
+use League\CommonMark\CommonMarkConverter;
 use PHPUnit\Framework\TestCase;
 use Spatie\Sheets\ContentParsers\MarkdownParser;
-use League\CommonMark\CommonMarkConverter;
 
 class MarkdownParserTest extends TestCase
 {

--- a/tests/ContentParsers/MarkdownWithFrontMatterParserTest.php
+++ b/tests/ContentParsers/MarkdownWithFrontMatterParserTest.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Sheets\Tests\ContentParsers;
 
+use League\CommonMark\CommonMarkConverter;
 use PHPUnit\Framework\TestCase;
 use Spatie\Sheets\ContentParsers\MarkdownWithFrontMatterParser;
-use League\CommonMark\CommonMarkConverter;
 
 class MarkdownWithFrontMatterParserTest extends TestCase
 {

--- a/tests/ContentParsers/YamlParserTest.php
+++ b/tests/ContentParsers/YamlParserTest.php
@@ -3,8 +3,6 @@
 namespace Spatie\Sheets\Tests\ContentParsers;
 
 use PHPUnit\Framework\TestCase;
-use Spatie\Sheets\ContentParsers\MarkdownParser;
-use League\CommonMark\CommonMarkConverter;
 use Spatie\Sheets\ContentParsers\YamlParser;
 
 class YamlParserTest extends TestCase
@@ -28,8 +26,8 @@ class YamlParserTest extends TestCase
                 'data' => [
                     'foo',
                     'bar',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expected, $yamlParser->parse($contents));

--- a/tests/Integration/CustomContentParserTest.php
+++ b/tests/Integration/CustomContentParserTest.php
@@ -2,10 +2,8 @@
 
 namespace Spatie\Sheets\Tests\Integration;
 
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Spatie\Sheets\ContentParsers\MarkdownParser;
-use Spatie\Sheets\PathParsers\SlugWithDateParser;
 use Spatie\Sheets\Sheet;
 use Spatie\Sheets\Sheets;
 

--- a/tests/Integration/CustomDiskTest.php
+++ b/tests/Integration/CustomDiskTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Sheets\Tests\Integration;
 
 use Illuminate\Support\Collection;
-use Spatie\Sheets\Sheets;
 use Spatie\Sheets\Sheet;
+use Spatie\Sheets\Sheets;
 
 class CustomDiskTest extends TestCase
 {
@@ -28,7 +28,7 @@ class CustomDiskTest extends TestCase
         $app['config']->set('sheets', [
             'collections' => [
                 'posts' => [
-                    'disk' => 'content'
+                    'disk' => 'content',
                 ],
             ],
         ]);

--- a/tests/Integration/CustomRepositoryTest.php
+++ b/tests/Integration/CustomRepositoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Spatie\Sheets\Tests\Integration;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Spatie\Sheets\ContentParsers\MarkdownParser;
+use Spatie\Sheets\PathParsers\SlugWithDateParser;
+use Spatie\Sheets\Repository;
+use Spatie\Sheets\Sheet;
+use Spatie\Sheets\Sheets;
+
+class CustomRepositoryTest extends TestCase
+{
+    /** @test */
+    public function it_can_maintain_a_collection_with_a_custom_repository()
+    {
+        $documents = $this->app->make(Sheets::class)->all();
+
+        $this->assertInstanceOf(Collection::class, $documents);
+        $this->assertCount(2, $documents);
+        $this->assertContainsOnlyInstancesOf(Sheet::class, $documents);
+
+        $this->assertEquals('foo', $documents[0]->path);
+        $this->assertEquals('bar', $documents[0]->foo);
+
+        $this->assertEquals('bar', $documents[1]->path);
+        $this->assertEquals('bar', $documents[1]->foo);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('sheets', [
+            'collections' => [
+                'null' => [
+                    'repository' => StaticRepository::class,
+                ],
+            ],
+        ]);
+    }
+}
+
+final class StaticRepository implements Repository
+{
+    public function all(): Collection
+    {
+        return new Collection([
+            $this->get('foo'),
+            $this->get('bar'),
+        ]);
+    }
+
+    public function get(string $path): ?Sheet
+    {
+        return new Sheet([
+            'path' => $path,
+            'foo' => 'bar',
+        ]);
+    }
+}

--- a/tests/Integration/CustomRepositoryTest.php
+++ b/tests/Integration/CustomRepositoryTest.php
@@ -2,10 +2,7 @@
 
 namespace Spatie\Sheets\Tests\Integration;
 
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Spatie\Sheets\ContentParsers\MarkdownParser;
-use Spatie\Sheets\PathParsers\SlugWithDateParser;
 use Spatie\Sheets\Repository;
 use Spatie\Sheets\Sheet;
 use Spatie\Sheets\Sheets;

--- a/tests/Integration/CustomSheetClassTest.php
+++ b/tests/Integration/CustomSheetClassTest.php
@@ -5,7 +5,6 @@ namespace Spatie\Sheets\Tests\Integration;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Spatie\Sheets\PathParsers\SlugWithDateParser;
-use Spatie\Sheets\Sheet;
 use Spatie\Sheets\Sheets;
 use Spatie\Sheets\Tests\Integration\DummySheets\Post;
 

--- a/tests/Integration/DefaultConfigTest.php
+++ b/tests/Integration/DefaultConfigTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Sheets\Tests\Integration;
 
 use Illuminate\Support\Collection;
-use Spatie\Sheets\Sheets;
 use Spatie\Sheets\Sheet;
+use Spatie\Sheets\Sheets;
 
 class DefaultConfigTest extends TestCase
 {

--- a/tests/Integration/ExplicitDefaultCollectionTest.php
+++ b/tests/Integration/ExplicitDefaultCollectionTest.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\Sheets\Tests\Integration;
 
-use Illuminate\Support\Collection;
 use Spatie\Sheets\PathParsers\SlugWithDateParser;
-use Spatie\Sheets\Sheet;
 use Spatie\Sheets\Sheets;
 use Spatie\Sheets\Tests\Integration\DummySheets\Page;
 use Spatie\Sheets\Tests\Integration\DummySheets\Post;

--- a/tests/Integration/ImplicitDefaultCollectionTest.php
+++ b/tests/Integration/ImplicitDefaultCollectionTest.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\Sheets\Tests\Integration;
 
-use Illuminate\Support\Collection;
 use Spatie\Sheets\PathParsers\SlugWithDateParser;
-use Spatie\Sheets\Sheet;
 use Spatie\Sheets\Sheets;
 use Spatie\Sheets\Tests\Integration\DummySheets\Page;
 use Spatie\Sheets\Tests\Integration\DummySheets\Post;

--- a/tests/Integration/MultipleCollectionsTest.php
+++ b/tests/Integration/MultipleCollectionsTest.php
@@ -4,7 +4,6 @@ namespace Spatie\Sheets\Tests\Integration;
 
 use Illuminate\Support\Collection;
 use Spatie\Sheets\PathParsers\SlugWithDateParser;
-use Spatie\Sheets\Sheet;
 use Spatie\Sheets\Sheets;
 use Spatie\Sheets\Tests\Integration\DummySheets\Page;
 use Spatie\Sheets\Tests\Integration\DummySheets\Post;

--- a/tests/PathParsers/SlugWithOrderParserTest.php
+++ b/tests/PathParsers/SlugWithOrderParserTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Sheets\Tests\PathParsers;
 
-use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Spatie\Sheets\PathParsers\SlugWithOrderParser;
 

--- a/tests/Repositories/FilesystemRepositoryTest.php
+++ b/tests/Repositories/FilesystemRepositoryTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Sheets\Tests\Repositories;
 
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 use Spatie\Sheets\Repositories\FilesystemRepository;
 use Spatie\Sheets\Sheet;
-use Illuminate\Support\Collection;
 use Spatie\Sheets\Tests\Concerns\UsesFactory;
 use Spatie\Sheets\Tests\Concerns\UsesFilesystem;
 

--- a/tests/SheetTest.php
+++ b/tests/SheetTest.php
@@ -3,12 +3,12 @@
 namespace Spatie\Sheets\Tests;
 
 use ArrayAccess;
-use ReflectionClass;
-use JsonSerializable;
-use Spatie\Sheets\Sheet;
-use PHPUnit\Framework\TestCase;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Spatie\Sheets\Sheet;
 
 class SheetTest extends TestCase
 {


### PR DESCRIPTION
This is an idea - the unittest isn't perfect (two classes in one file) and the whole could be breaking if someone tries to create the FileSystemRepository by his own. The documented API keeps intakt and isn't breaking.
This line is the key part of the whole PR:
```php
$this->app->make($config['repository'], compact('factory', 'config'));
```
It utilizes the container to create the repository class and passes in the factory and the whole config array. This way the repository can use every container service binding in its construct and access every config key. So custom repositories could also add custom keys - like spreadsheet access data to pull data from a Google Spreadsheet or Contentful credentials or whatever the user wants to use as the base of his repository. 

It's again part of my Stancy project to allow the users switch to any other common service as data/content storage. At the end it could even use an API in the background to retrieve weather data or whatever.

PS: I've run StyleCI over the whole repo - that's why some files are changed which aren't part of the original commit.