### PR TITLE
cache sheet instances for current runtime

### DIFF
--- a/src/Repositories/FilesystemRepository.php
+++ b/src/Repositories/FilesystemRepository.php
@@ -6,11 +6,14 @@ use Illuminate\Contracts\Filesystem\Factory as FilesystemManagerContract;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Spatie\Sheets\Factory;
+use Spatie\Sheets\Repositories\Traits\CachedSheets;
 use Spatie\Sheets\Repository;
 use Spatie\Sheets\Sheet;
 
 class FilesystemRepository implements Repository
 {
+    use CachedSheets;
+
     /** @var \Spatie\Sheets\Factory */
     protected $factory;
 
@@ -29,15 +32,15 @@ class FilesystemRepository implements Repository
 
     public function get(string $path): ?Sheet
     {
-        if (! Str::endsWith($path, $this->extension)) {
-            $path = "{$path}.{$this->extension}";
-        }
+        $path = $this->normalizePath($path);
 
         if (! $this->filesystem->exists($path)) {
             return null;
         }
 
-        return $this->factory->make($path, $this->filesystem->get($path));
+        return $this->remember($path, function (string $path): Sheet {
+            return $this->factory->make($path, $this->filesystem->get($path));
+        });
     }
 
     public function all(): Collection
@@ -49,5 +52,10 @@ class FilesystemRepository implements Repository
             ->map(function (string $path) {
                 return $this->get($path);
             });
+    }
+
+    protected function normalizePath(string $path): string
+    {
+        return Str::finish($path, ".{$this->extension}");
     }
 }

--- a/src/Repositories/Traits/CachedSheets.php
+++ b/src/Repositories/Traits/CachedSheets.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\Sheets\Repositories\Traits;
+
+use Closure;
+use Spatie\Sheets\Sheet;
+
+trait CachedSheets
+{
+    protected $cache = [];
+
+    protected function remember(string $path, Closure $callback): Sheet
+    {
+        $path = $this->normalizePath($path);
+
+        if (! isset($this->cache[$path])) {
+            $this->cache[$path] = $callback($path);
+        }
+
+        return $this->cache[$path];
+    }
+
+    public function forget(string $path): void
+    {
+        unset($this->cache[$this->normalizePath($path)]);
+    }
+
+    abstract protected function normalizePath(string $path): string;
+}

--- a/tests/Repositories/FilesystemRepositoryTest.php
+++ b/tests/Repositories/FilesystemRepositoryTest.php
@@ -64,4 +64,40 @@ class FilesystemRepositoryTest extends TestCase
 
         $this->assertNull($filesystemRepository->get('invalid_path'));
     }
+
+    /** @test */
+    public function it_gets_the_same_sheet_instance()
+    {
+        $filesystemRepository = new FilesystemRepository(
+            $this->createFactory(),
+            $this->createFilesystem()
+        );
+
+        $sheet1 = $filesystemRepository->get('hello-world');
+        $this->assertInstanceOf(Sheet::class, $sheet1);
+
+        $sheet2 = $filesystemRepository->get('hello-world.md');
+        $this->assertInstanceOf(Sheet::class, $sheet2);
+
+        $this->assertSame($sheet1, $sheet2);
+    }
+
+    /** @test */
+    public function it_can_forget_a_cached_sheet()
+    {
+        $filesystemRepository = new FilesystemRepository(
+            $this->createFactory(),
+            $this->createFilesystem()
+        );
+
+        $sheet1 = $filesystemRepository->get('hello-world');
+        $this->assertInstanceOf(Sheet::class, $sheet1);
+
+        $filesystemRepository->forget('hello-world');
+
+        $sheet2 = $filesystemRepository->get('hello-world');
+        $this->assertInstanceOf(Sheet::class, $sheet2);
+
+        $this->assertNotSame($sheet1, $sheet2);
+    }
 }


### PR DESCRIPTION
fixes #46 

This PR could be breaking for users relying on different sheet instances and/or updating a sheet content file during runtime.

