### PR TITLE
bind commonmark as singleton to all interfaces

### DIFF
--- a/src/SheetsServiceProvider.php
+++ b/src/SheetsServiceProvider.php
@@ -5,7 +5,7 @@ namespace Spatie\Sheets;
 use Illuminate\Support\ServiceProvider;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\ConverterInterface;
-use Spatie\Sheets\ContentParsers\MarkdownParser;
+use League\CommonMark\MarkdownConverterInterface;
 use Spatie\Sheets\ContentParsers\MarkdownWithFrontMatterParser;
 use Spatie\Sheets\PathParsers\SlugParser;
 use Spatie\Sheets\Repositories\FilesystemRepository;
@@ -31,8 +31,10 @@ class SheetsServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/sheets.php', 'sheets');
 
-        if (! $this->app->bound(ConverterInterface::class)) {
-            $this->app->singleton(ConverterInterface::class, CommonMarkConverter::class);
+        if (! $this->app->bound(CommonMarkConverter::class)) {
+            $this->app->singleton(CommonMarkConverter::class);
+            $this->app->alias(CommonMarkConverter::class, MarkdownConverterInterface::class);
+            $this->app->alias(CommonMarkConverter::class, ConverterInterface::class);
         }
 
         $this->app->singleton(Sheets::class, function () {


### PR DESCRIPTION
Reasons for this change:
* `ConverterInterface` is deprecated and replaced by `MarkdownConverterInterface`
* `app(CommonMarkConverter::class)` hasn't returned the singleton

Now you can use all three to get the same singleton.