### PR TITLE
allow to directly pass the collection name into sheets() helper function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\Sheets\Repository;
 use Spatie\Sheets\Sheets;
 
 if (! function_exists('sheets')) {
@@ -8,7 +9,7 @@ if (! function_exists('sheets')) {
      *
      * @return \Spatie\Sheets\Repository|\Spatie\Sheets\Sheets
      */
-    function sheets(?string $collection = null)
+    function sheets(?string $collection = null): Repository
     {
         if ($collection === null) {
             return app(Sheets::class);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,8 +3,17 @@
 use Spatie\Sheets\Sheets;
 
 if (! function_exists('sheets')) {
-    function sheets(): Sheets
+    /**
+     * @param string|null $collection
+     *
+     * @return \Spatie\Sheets\Repository|\Spatie\Sheets\Sheets
+     */
+    function sheets(?string $collection = null)
     {
-        return app(Sheets::class);
+        if ($collection === null) {
+            return app(Sheets::class);
+        }
+
+        return app(Sheets::class)->collection($collection);
     }
 }

--- a/tests/Integration/DefaultConfigTest.php
+++ b/tests/Integration/DefaultConfigTest.php
@@ -18,6 +18,26 @@ class DefaultConfigTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Sheet::class, $content);
     }
 
+    /** @test */
+    public function it_can_retrieve_a_default_collection_via_helper()
+    {
+        $content = sheets()->all();
+
+        $this->assertInstanceOf(Collection::class, $content);
+        $this->assertCount(2, $content);
+        $this->assertContainsOnlyInstancesOf(Sheet::class, $content);
+    }
+
+    /** @test */
+    public function it_can_retrieve_an_explicit_collection_via_helper()
+    {
+        $content = sheets('content')->all();
+
+        $this->assertInstanceOf(Collection::class, $content);
+        $this->assertCount(2, $content);
+        $this->assertContainsOnlyInstancesOf(Sheet::class, $content);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('filesystems.disks.content', [


### PR DESCRIPTION
Before you had to call the `collection()` method on the `sheets()` helper function.
After you can pass the collection name in the `sheets()` helper function.
This will shorten code and make the helper function a bit more helpful.
```php
// before
sheets()->collection('posts')->all();

// after
sheets('posts')->all();
```