### PR TITLE
[BC] rename allLazy() to cursor()

### DIFF
--- a/src/Repositories/FilesystemRepository.php
+++ b/src/Repositories/FilesystemRepository.php
@@ -46,10 +46,10 @@ class FilesystemRepository implements Repository
 
     public function all(): Collection
     {
-        return $this->allLazy()->collect();
+        return $this->cursor()->collect();
     }
 
-    public function allLazy(): LazyCollection
+    public function cursor(): LazyCollection
     {
         return LazyCollection::make($this->filesystem->allFiles())
             ->filter(function (string $path) {

--- a/tests/Repositories/FilesystemRepositoryTest.php
+++ b/tests/Repositories/FilesystemRepositoryTest.php
@@ -63,7 +63,7 @@ class FilesystemRepositoryTest extends TestCase
             $this->createFilesystem()
         );
 
-        $sheets = $filesystemRepository->allLazy();
+        $sheets = $filesystemRepository->cursor();
 
         $this->assertInstanceOf(LazyCollection::class, $sheets);
         $this->assertCount(2, $sheets);


### PR DESCRIPTION
After the renaming it will follow the Laravel conventions.