### PR TITLE
Adds `league/commonmark` 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/filesystem": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "league/commonmark": "^1.0",
+        "league/commonmark": "^1.0|^2.0",
         "spatie/yaml-front-matter": "^2.0",
         "symfony/yaml": "^4.0|^5.0"
     },


### PR DESCRIPTION
It was causing conflicts with packages like `spatie/commonmark-shiki-highlighter` and `spatie/laravel-markdown`.

See:
https://github.com/spatie/commonmark-shiki-highlighter/blob/ed4e54de8dea621fe70fd6d7d65a399fedf818ef/composer.json#L20

https://github.com/laravel/framework/blob/3e8f7fa0c40a2802298ebb64c6485a413d2eccfb/composer.json#L26

https://github.com/spatie/laravel-markdown/blob/d9b88ddf4001a3192fa9c3ecd17e32e518ab5391/composer.json#L24

the commands are in order:

<img width="1983" alt="screenshot 208" src="https://user-images.githubusercontent.com/13007665/135968835-e16059cb-3026-43af-9ad6-c84d3cc3b9f6.png">
<img width="694" alt="screenshot 209" src="https://user-images.githubusercontent.com/13007665/135968842-0efcc7da-c1cd-4ff5-b16c-fbc8d1ba8b87.png">
<img width="1629" alt="screenshot 210" src="https://user-images.githubusercontent.com/13007665/135968845-ae17f3cf-4ba3-4634-b5f5-8e88e848d064.png">

🤦‍♂️

Thank you.