### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,16 +9,13 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.0, 7.4, 7.3]
-                laravel: [6.*, 7.*, 8.*]
+                php: [8.1, 8.0]
+                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
+
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
@@ -30,7 +27,7 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-                    coverage: none
+                    coverage: noneW
 
             -   name: Install dependencies
                 run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-                    coverage: noneW
+                    coverage: none
 
             -   name: Install dependencies
                 run: |

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/filesystem": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^8.71",
+        "illuminate/filesystem": "^8.71",
+        "illuminate/support": "^8.71",
         "league/commonmark": "^1.0",
         "spatie/yaml-front-matter": "^2.0",
         "symfony/yaml": "^4.0|^5.0"
     },
     "require-dev": {
         "league/flysystem": "^1.0.8",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "orchestra/testbench": "^6.23",
+        "phpunit/phpunit": "^9.4"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This PR adds support for PHP 8.1 and drops support for PHP 7 as well as Laravel 6.x and 7.x.