### PR TITLE
Update Default Sheet Class Path

### DIFF
--- a/config/sheets.php
+++ b/config/sheets.php
@@ -9,7 +9,7 @@ return [
 
         'posts' => [
             'disk' => 'posts',
-            'sheet_class' => App\Post::class,
+            'sheet_class' => App\Models\Post::class,
             'path_parser' => Spatie\Sheets\PathParsers\SlugWithDateParser::class,
             'content_parser' => Spatie\Sheets\ContentParsers\MarkdownParser::class,
             'extension' => 'txt',


### PR DESCRIPTION
This pull request addresses a modification in the default sheet class path in the configuration. Previously, the path was set to the App\Post::class directory. This PR changes the path to point towards the App\Models\Post::class directory.

This change ensures that the sheet class path aligns with the Laravel 8.x and onwards standard directory structure where the models are kept in a separate directory named 'Models' inside the 'App' directory.

The modification does not affect any existing functionality and ensures better compliance with the Laravel directory structure convention. Please review and merge if everything looks good.