### PR TITLE
Change convertToHtml() to convert() because convertToHtml() has been deprecated since commonmark 2.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ class MarkdownWithFrontMatterParser implements ContentParser
 
         return array_merge(
             $document->matter(),
-            ['contents' => $this->commonMarkConverter->convertToHtml($document->body())]
+            ['contents' => $this->commonMarkConverter->convert($document->body())]
         );
     }
 }

--- a/src/ContentParsers/MarkdownParser.php
+++ b/src/ContentParsers/MarkdownParser.php
@@ -18,7 +18,7 @@ class MarkdownParser implements ContentParser
 
     public function parse(string $contents): array
     {
-        $htmlContents = $this->commonMarkConverter->convertToHtml($contents);
+        $htmlContents = $this->commonMarkConverter->convert($contents);
 
         return [
             'contents' => new HtmlString($htmlContents),

--- a/src/ContentParsers/MarkdownWithFrontMatterParser.php
+++ b/src/ContentParsers/MarkdownWithFrontMatterParser.php
@@ -21,7 +21,7 @@ class MarkdownWithFrontMatterParser implements ContentParser
     {
         $document = YamlFrontMatter::parse($contents);
 
-        $htmlContents = $this->commonMarkConverter->convertToHtml($document->body());
+        $htmlContents = $this->commonMarkConverter->convert($document->body());
 
         return array_merge(
             $document->matter(),


### PR DESCRIPTION
See this [line](https://github.com/thephpleague/commonmark/blob/91c24291965bd6d7c46c46a12ba7492f83b1cadf/src/MarkdownConverter.php#L77) which triggers the deprecation warning.